### PR TITLE
Update .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,8 +36,6 @@ module.exports = {
     "jsx-a11y/accessible-emoji": "off",
     "react/prop-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/ban-ts-comment": "off",


### PR DESCRIPTION
# Description

The `simple-import-sort` was giving an error which is shown in the image. It was not detecting the sorted imports and kept giving an error message. 

<img width="962" alt="image" src="https://user-images.githubusercontent.com/39924479/213408271-e65d65d0-5467-4e7d-abea-dca97cad3b1d.png">



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

